### PR TITLE
Drop incompatible topology from Aer credentials

### DIFF
--- a/prefect_qiskit/vendors/qiskit_aer/credentials.py
+++ b/prefect_qiskit/vendors/qiskit_aer/credentials.py
@@ -96,7 +96,7 @@ class QiskitAerCredentials(CredentialsBlock):
         title="Apply Noise",
     )
 
-    coupling_map_type: Literal["full", "ring", "linear", "grid", "hexagonal", "heavy-hex", "heavy_square"] = Field(
+    coupling_map_type: Literal["full", "ring", "linear"] = Field(
         default="linear",
         description=(
             "Topology of coupling map. Actual connections are automatically generated from the selected topology."
@@ -131,26 +131,6 @@ class QiskitAerCredentials(CredentialsBlock):
                 )
             case "linear":
                 coupling_map = CouplingMap.from_line(
-                    num_qubits=self.num_qubits,
-                    bidirectional=True,
-                )
-            case "grid":
-                coupling_map = CouplingMap.from_grid(
-                    num_qubits=self.num_qubits,
-                    bidirectional=True,
-                )
-            case "hexagonal":
-                coupling_map = CouplingMap.from_hexagonal_lattice(
-                    num_qubits=self.num_qubits,
-                    bidirectional=True,
-                )
-            case "heavy-hex":
-                coupling_map = CouplingMap.from_heavy_hex(
-                    num_qubits=self.num_qubits,
-                    bidirectional=True,
-                )
-            case "heavy_square":
-                coupling_map = CouplingMap.from_heavy_square(
                     num_qubits=self.num_qubits,
                     bidirectional=True,
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def bell_circ() -> QuantumCircuit:
 
 
 @pytest.fixture
-def aer_credentials_2q() -> QuantumCircuit:
+def aer_credentials_2q() -> QiskitAerCredentials:
     """Fixture to return Aer credentials with 2Q generic backend."""
     return QiskitAerCredentials(
         num_qubits=2,


### PR DESCRIPTION
This PR just drops incompatible topologies (grid, hexagonal, heavy-hex, heavy_square) from the list, instead of implicitly inferring the factory function signature. We can revisit this issue based on user request for other coupling topologies.

close #5 