### PR TITLE
Remove nest_asyncio from dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "prefect",
     "qiskit>=2.1",
     "aiohttp",
-    "nest-asyncio",
     "typing_extensions",
     # vendor: IBM
     "ibm_cloud_sdk_core",

--- a/uv.lock
+++ b/uv.lock
@@ -1406,15 +1406,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nest-asyncio"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1778,7 +1769,6 @@ dependencies = [
     { name = "aiohttp" },
     { name = "diskcache" },
     { name = "ibm-cloud-sdk-core" },
-    { name = "nest-asyncio" },
     { name = "prefect" },
     { name = "qiskit" },
     { name = "qiskit-aer" },
@@ -1814,7 +1804,6 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.15.0" },
-    { name = "nest-asyncio" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "prefect" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.4" },


### PR DESCRIPTION
[nest_asyncio](https://github.com/erdewit/nest_asyncio) is used to validate resource name with `QuantumRuntime` from an environment with an active event loop, such as Jupyter notebook. Since this package is public archive, it's better to use alternative. Prefect provides a utility `run_coro_as_sync` which can be used for the same purpose. This PR replaced nest_asyncio with run_coro_as_sync.