### PR TITLE
Expose Prefect primitive runner task

### DIFF
--- a/prefect_qiskit/primitives/runner.py
+++ b/prefect_qiskit/primitives/runner.py
@@ -13,7 +13,6 @@
 
 from typing import Literal
 
-from prefect import task
 from prefect.artifacts import create_table_artifact
 from prefect.blocks.abstract import CredentialsBlock
 from prefect.context import TaskRunContext
@@ -26,6 +25,9 @@ from qiskit.primitives.containers.sampler_pub import SamplerPub
 from prefect_qiskit.exceptions import RuntimeJobFailure
 from prefect_qiskit.models import JobMetrics
 from prefect_qiskit.primitives.job import PrimitiveJob
+
+# TODO integration of metrics database
+# TODO automatic job split (workflow optimization)
 
 
 async def retry_on_failure(_task, _task_run, state):
@@ -41,14 +43,6 @@ async def retry_on_failure(_task, _task_run, state):
         return False
 
 
-# TODO integration of metrics database
-# TODO automatic job split (workflow optimization)
-
-
-@task(
-    name="run_primitive",
-    retry_condition_fn=retry_on_failure,
-)
 async def run_primitive(
     *,
     primitive_blocs: list[SamplerPub] | list[EstimatorPub],
@@ -58,9 +52,9 @@ async def run_primitive(
     enable_analytics: bool = True,
     options: dict | None = None,
 ) -> PrimitiveResult:
-    """
-    This function implements a Prefect task to manage the execution of
-    Qiskit Primitives on an abstract layer,
+    """A core logic to make a primitive job and returns a result.
+
+    This function manages the execution of Qiskit Primitives on an abstract layer,
     providing built-in execution failure protection.
 
     It accepts PUBs and options, submitting this data to quantum computers via the vendor's API.

--- a/tests/vendors/ibm/test_e2e.py
+++ b/tests/vendors/ibm/test_e2e.py
@@ -178,7 +178,7 @@ def test_sampler_e2e(
         "program_type": "sampler",
         "num_pubs": 1,
         "job_id": "test-job-id-123",
-        "tags": ["primitive-execute"],
+        "tags": [],
         "timestamp.created": ANY,
         "timestamp.started": ANY,
         "timestamp.completed": ANY,


### PR DESCRIPTION
In the current implementation `QuantumRuntime.sampler`, for example, calls a private method `._setup_runner` to create a Prefect task to execute the Qiskit Primitives. This means the Prefect Task object is hidden from the end users, which was intention of this package to better align with the conventional Qiskit programming syntax.

However, as a Prefect user, I also want to handle raw Task object to customize execution. This PR turns the task factory method into public so that experienced Prefect users can control more Prefect features.

The default tag of `primitive-execute` is also dropped because tags depend on the design of flow.