### PR TITLE
Reuse HTTP Session for IBM Quantum

### DIFF
--- a/prefect_qiskit/runtime.py
+++ b/prefect_qiskit/runtime.py
@@ -27,13 +27,11 @@ from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect.blocks.core import Block
 from prefect.cache_policies import NO_CACHE, CacheKeyFnPolicy
 from prefect.tasks import Task
-from prefect.utilities.asyncutils import run_coro_as_sync
-from pydantic import Field, model_validator
+from pydantic import Field
 from qiskit.primitives import PrimitiveResult
 from qiskit.primitives.containers.estimator_pub import EstimatorPub, EstimatorPubLike
 from qiskit.primitives.containers.sampler_pub import SamplerPub, SamplerPubLike
 from qiskit.transpiler import Target
-from typing_extensions import Self
 
 from prefect_qiskit.models import AsyncRuntimeClientInterface
 from prefect_qiskit.primitives.runner import retry_on_failure, run_primitive
@@ -168,18 +166,6 @@ class QuantumRuntime(Block):
         ),
         title="Execution Cache",
     )
-
-    @model_validator(mode="after")
-    def check_resource(self) -> Self:
-        client: AsyncRuntimeClientInterface = self.credentials.get_client()
-
-        allowed_list = run_coro_as_sync(client.get_resources())
-        if self.resource_name not in allowed_list:
-            raise ValueError(
-                f"Resource name {self.resource_name} is not available under your account. "
-                f"Following resources are available: {', '.join(allowed_list)}."
-            )
-        return self
 
     async def async_get_target(
         self,

--- a/prefect_qiskit/vendors/ibm_quantum/client.py
+++ b/prefect_qiskit/vendors/ibm_quantum/client.py
@@ -15,13 +15,15 @@ See the following link for the REST API specification.
 https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest#qiskit-runtime-rest-api
 """
 
+import asyncio
+import functools
 import json
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+import threading
 from datetime import datetime
 from typing import Any, Literal
 
 import aiohttp
+from cachetools import LRUCache
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 from pydantic import SecretStr, ValidationError
 from qiskit.primitives.containers import PrimitiveResult
@@ -42,57 +44,72 @@ DEFAULT_AUTH_URL: str = "https://iam.cloud.ibm.com"
 DEFAULT_RUNTIME_URL: str = "https://quantum.cloud.ibm.com/api/v1/"
 
 
-@asynccontextmanager
-async def runtime_session_ctx(
-    client: "IBMQuantumPlatformClient",
-    timeout: int = 30,
-) -> AsyncGenerator[aiohttp.ClientSession, None]:
-    """Asynchronous HTTP session context with error handling.
+def handle_error(method):
+    """A method decorator to prevent accidental secrets print out and error typecast."""
 
-    Automatically add authentication and CRN in the HTTP request header.
-    Catch client error not to print sensitive header in the stack trace.
-    """
-    timeout = aiohttp.ClientTimeout(total=timeout)
-    headers = {
-        "IBM-API-Version": "2025-01-01",
-        "Accept": "application/json",
-        "Authorization": f"Bearer {client.auth.token_manager.get_token()}",
-        "Service-CRN": client.crn,
-    }
-    try:
-        async with aiohttp.ClientSession(
-            timeout=timeout,
-            headers=headers,
-            base_url=client.runtime_endpoint_url,
-            raise_for_status=True,
-        ) as session:
-            yield session
-    except aiohttp.ClientResponseError as ex:
-        raise RuntimeJobFailure(
-            reason=f"HTTP {ex.status} on {ex.request_info.url}.",
-            retry=True,
-        ) from None
-    except aiohttp.ClientConnectionError:
-        raise RuntimeJobFailure(
-            reason=f"Connection failed to {client.runtime_endpoint_url}.",
-            retry=True,
-        ) from None
-    except TimeoutError:
-        raise RuntimeJobFailure(
-            reason="HTTP request timed out.",
-            retry=True,
-        ) from None
-    except aiohttp.ClientError as ex:
-        raise RuntimeJobFailure(
-            reason=f"General HTTP client error {ex.__class__.__name__}.",
-            retry=True,
-        ) from None
+    @functools.wraps(method)
+    async def wrapper(self, *args, **kwargs):
+        try:
+            return await method(self, *args, **kwargs)
+        except aiohttp.ClientResponseError as ex:
+            raise RuntimeJobFailure(
+                reason=f"HTTP {ex.status} on {ex.request_info.url!r}.",
+                retry=True,
+            ) from None
+        except aiohttp.ClientConnectionError:
+            raise RuntimeJobFailure(
+                reason=f"Connection failed to {self.runtime_endpoint_url!r}.",
+                retry=True,
+            ) from None
+        except TimeoutError:
+            raise RuntimeJobFailure(
+                reason="HTTP request timed out.",
+                retry=True,
+            ) from None
+        except aiohttp.ClientError as ex:
+            raise RuntimeJobFailure(
+                reason=f"General HTTP client error {ex.__class__.__name__}.",
+                retry=True,
+            ) from None
+
+    return wrapper
+
+
+class SessionCache(LRUCache):
+    """LRU cache with session closing at expire."""
+
+    def popitem(self):
+        """Remove session with termination of removed session."""
+        endpoint, session = super().popitem()
+        if not session.closed:
+            asyncio.run(session.close())
+        return endpoint, session
 
 
 class IBMQuantumPlatformClient(LoggingMixin):
-    """Adaptor interface for IBM Quantum Platform cloud client."""
+    """Adaptor interface for IBM Quantum Platform cloud client.
+
+    .. note::
+        This class maintains a **class-level cache** of HTTP sessions, keyed by endpoint URL.
+        The cache enables efficient reuse of TCP connections for frequent HTTP requests.
+
+        By design, each cached session keeps its underlying TCP socket open
+        for the duration of the TCP keep-alive cycle, rather than closing it after each request.
+
+        When this class is initialized across multiple processes (for example, via
+        :class:`concurrent.futures.ProcessPoolExecutor`), each process establishes its
+        own socket per endpoint—even if no HTTP request is made.
+
+        Because this class implements :class:`AsyncRuntimeClientInterface`, it assumes
+        that concurrent operations are coordinated by **asyncio**, rather than by
+        multiprocessing or distributed task runners.
+
+    """
 
     AVOID_RETRY = [9999]
+
+    _sessions = SessionCache(maxsize=3)
+    _lock = threading.Lock()
 
     def __init__(
         self,
@@ -116,42 +133,92 @@ class IBMQuantumPlatformClient(LoggingMixin):
         self.crn = crn
         self.runtime_endpoint_url = runtime_endpoint_url
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__} runtime_endpoint_url={self.runtime_endpoint_url!r}>"
+
+    def _get_session(
+        self,
+    ) -> aiohttp.ClientSession:
+        # Lock is necessary because Prefect tasks calling this client
+        # might be run by the ThreadPoolTaskRunner. In this case,
+        # race condition may occur and multiple HTTP sessions are initialized for the same key.
+        # This eventually results in the socket leakage.
+        with self._lock:
+            session = self._sessions.get(self.runtime_endpoint_url)
+            if session is None or session.closed:
+                self.logger.debug(f"Creating new HTTP session for {self.runtime_endpoint_url!r}")
+                session = aiohttp.ClientSession(
+                    base_url=self.runtime_endpoint_url,
+                    timeout=aiohttp.ClientTimeout(30),
+                    raise_for_status=True,
+                )
+                self._sessions[self.runtime_endpoint_url] = session
+        return session
+
+    def _get_headers(
+        self,
+    ) -> dict[str, str]:
+        headers = {
+            "IBM-API-Version": "2025-01-01",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.auth.token_manager.get_token()}",
+            "Service-CRN": self.crn,
+        }
+        return headers
+
+    @handle_error
     async def check_resource_available(
         self,
         resource_name: str,
     ) -> bool:
-        async with runtime_session_ctx(self) as session:
-            async with session.get(f"backends/{resource_name}/status") as resp:
-                self.logger.debug(f"GET request for {resp.url}")
-                ret = await resp.json()
+        session = self._get_session()
+        async with session.get(
+            f"backends/{resource_name}/status",
+            headers=self._get_headers(),
+        ) as resp:
+            self.logger.debug(f"GET request for {resp.url}")
+            ret = await resp.json()
         return ret.get("state", False)
 
+    @handle_error
     async def get_resources(
         self,
     ) -> list[str]:
-        async with runtime_session_ctx(self) as session:
-            async with session.get("backends") as resp:
-                self.logger.debug(f"GET request for {resp.url}")
-                ret = await resp.json()
+        session = self._get_session()
+        async with session.get(
+            "backends",
+            headers=self._get_headers(),
+        ) as resp:
+            self.logger.debug(f"GET request for {resp.url}")
+            ret = await resp.json()
         devices = ret.get("devices", [])
         return [d["name"] for d in devices if d["status"]["name"] == "online"]
 
+    @handle_error
     async def get_target(
         self,
         resource_name: str,
     ) -> Target:
-        async with runtime_session_ctx(self) as session:
-            async with session.get(f"backends/{resource_name}/configuration") as resp:
-                self.logger.debug(f"GET request for {resp.url}")
-                configuration_dict = await resp.json()
-            async with session.get(f"backends/{resource_name}/properties") as resp:
-                self.logger.debug(f"GET request for {resp.url}")
-                properties_dict = await resp.json()
+        session = self._get_session()
+        headers = self._get_headers()
+        async with session.get(
+            f"backends/{resource_name}/configuration",
+            headers=headers,
+        ) as resp:
+            self.logger.debug(f"GET request for {resp.url}")
+            configuration_dict = await resp.json()
+        async with session.get(
+            f"backends/{resource_name}/properties",
+            headers=headers,
+        ) as resp:
+            self.logger.debug(f"GET request for {resp.url}")
+            properties_dict = await resp.json()
         return convert_to_target(
             configuration=BackendConfiguration.from_dict(configuration_dict),
             properties=BackendProperties.from_dict(properties_dict),
         )
 
+    @handle_error
     async def run_primitive(
         self,
         program_id: Literal["sampler", "estimator"],
@@ -217,11 +284,15 @@ class IBMQuantumPlatformClient(LoggingMixin):
         self.logger.debug(f"Submitting the following payload: {payload}")
         data = json.dumps(payload, cls=RuntimeEncoder)
 
-        async with runtime_session_ctx(self, timeout=900) as session:
-            async with session.post("jobs", data=data) as resp:
-                self.logger.debug(f"POST request for {resp.url}")
-                ret = await resp.json()
-
+        session = self._get_session()
+        async with session.post(
+            "jobs",
+            data=data,
+            headers=self._get_headers(),
+            timeout=aiohttp.ClientTimeout(900),
+        ) as resp:
+            self.logger.debug(f"POST request for {resp.url}")
+            ret = await resp.json()
         if job_id := ret.get("id", None):
             self.logger.info(f"Job started with job ID {job_id}.")
         else:
@@ -231,14 +302,18 @@ class IBMQuantumPlatformClient(LoggingMixin):
             )
         return job_id
 
+    @handle_error
     async def get_primitive_result(
         self,
         job_id: str,
     ) -> PrimitiveResult:
-        async with runtime_session_ctx(self) as session:
-            async with session.get(f"jobs/{job_id}/results") as resp:
-                self.logger.debug(f"GET request for {resp.url}")
-                ret = await resp.text()
+        session = self._get_session()
+        async with session.get(
+            f"jobs/{job_id}/results",
+            headers=self._get_headers(),
+        ) as resp:
+            self.logger.debug(f"GET request for {resp.url}")
+            ret = await resp.text()
         # Assume job ID is valid.
         # This is true as long as job is not exposed to user program.
         results = ResultDecoder.decode(ret)
@@ -255,14 +330,18 @@ class IBMQuantumPlatformClient(LoggingMixin):
                 res.metadata["span"] = span_info
         return results
 
+    @handle_error
     async def get_job_status(
         self,
         job_id: str,
     ) -> JOB_STATUS:
-        async with runtime_session_ctx(self) as session:
-            async with session.get(f"jobs/{job_id}") as resp:
-                self.logger.debug(f"GET request for {resp.url}")
-                ret = await resp.json()
+        session = self._get_session()
+        async with session.get(
+            f"jobs/{job_id}",
+            headers=self._get_headers(),
+        ) as resp:
+            self.logger.debug(f"GET request for {resp.url}")
+            ret = await resp.json()
         job_state = ret.get("state", {})
 
         match status := ret.get("status", "unknown").upper():
@@ -304,14 +383,18 @@ class IBMQuantumPlatformClient(LoggingMixin):
                     retry=True,
                 )
 
+    @handle_error
     async def get_job_metrics(
         self,
         job_id: str,
     ) -> JobMetrics:
-        async with runtime_session_ctx(self) as session:
-            async with session.get(f"jobs/{job_id}/metrics") as resp:
-                self.logger.debug(f"GET request for {resp.url}")
-                ret = await resp.json()
+        session = self._get_session()
+        async with session.get(
+            f"jobs/{job_id}/metrics",
+            headers=self._get_headers(),
+        ) as resp:
+            self.logger.debug(f"GET request for {resp.url}")
+            ret = await resp.json()
 
         if "timestamps" in ret:
             try:

--- a/prefect_qiskit/vendors/ibm_quantum/client.py
+++ b/prefect_qiskit/vendors/ibm_quantum/client.py
@@ -19,6 +19,7 @@ import asyncio
 import functools
 import json
 import threading
+from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any, Literal
 
@@ -86,6 +87,32 @@ class SessionCache(LRUCache):
         return endpoint, session
 
 
+class ThreadAsyncLock:
+    """Hybrid lock mechanism to prevent race condition on session cache.
+
+    The :class:`IBMQuantumPlatformClient` implements the :class:`AsyncRuntimeClientInterface`,
+    and we assume its primary concurrency operation is asyncio.
+    However, within Prefect workflows, the :class:`QuantumRuntime` is often used
+    inside Prefect tasks, and such tasks can run through task runners.
+    Because the default task runner in Prefect is the :class:`ThreadPoolTaskRunner`,
+    we also need to consider the race condition by threading.
+
+    Without proper race condition handling, concurrent HTTP requests may
+    create multiple HTTP sessions, resulting in the socket leakage.
+    This hybrid lock prevents the race condition in both scenarios.
+    """
+
+    def __init__(self):
+        self.thread_lock = threading.Lock()
+        self.async_lock = asyncio.Lock()
+
+    @asynccontextmanager
+    async def acquire(self):
+        with self.thread_lock:
+            async with self.async_lock:
+                yield
+
+
 class IBMQuantumPlatformClient(LoggingMixin):
     """Adaptor interface for IBM Quantum Platform cloud client.
 
@@ -109,7 +136,7 @@ class IBMQuantumPlatformClient(LoggingMixin):
     AVOID_RETRY = [9999]
 
     _sessions = SessionCache(maxsize=3)
-    _lock = threading.Lock()
+    _lock = ThreadAsyncLock()
 
     def __init__(
         self,
@@ -136,14 +163,10 @@ class IBMQuantumPlatformClient(LoggingMixin):
     def __repr__(self):
         return f"<{self.__class__.__name__} runtime_endpoint_url={self.runtime_endpoint_url!r}>"
 
-    def _get_session(
+    async def _get_session(
         self,
     ) -> aiohttp.ClientSession:
-        # Lock is necessary because Prefect tasks calling this client
-        # might be run by the ThreadPoolTaskRunner. In this case,
-        # race condition may occur and multiple HTTP sessions are initialized for the same key.
-        # This eventually results in the socket leakage.
-        with self._lock:
+        async with self._lock.acquire():
             session = self._sessions.get(self.runtime_endpoint_url)
             if session is None or session.closed:
                 self.logger.debug(f"Creating new HTTP session for {self.runtime_endpoint_url!r}")
@@ -171,7 +194,7 @@ class IBMQuantumPlatformClient(LoggingMixin):
         self,
         resource_name: str,
     ) -> bool:
-        session = self._get_session()
+        session = await self._get_session()
         async with session.get(
             f"backends/{resource_name}/status",
             headers=self._get_headers(),
@@ -184,7 +207,7 @@ class IBMQuantumPlatformClient(LoggingMixin):
     async def get_resources(
         self,
     ) -> list[str]:
-        session = self._get_session()
+        session = await self._get_session()
         async with session.get(
             "backends",
             headers=self._get_headers(),
@@ -199,7 +222,7 @@ class IBMQuantumPlatformClient(LoggingMixin):
         self,
         resource_name: str,
     ) -> Target:
-        session = self._get_session()
+        session = await self._get_session()
         headers = self._get_headers()
         async with session.get(
             f"backends/{resource_name}/configuration",
@@ -284,7 +307,7 @@ class IBMQuantumPlatformClient(LoggingMixin):
         self.logger.debug(f"Submitting the following payload: {payload}")
         data = json.dumps(payload, cls=RuntimeEncoder)
 
-        session = self._get_session()
+        session = await self._get_session()
         async with session.post(
             "jobs",
             data=data,
@@ -307,7 +330,7 @@ class IBMQuantumPlatformClient(LoggingMixin):
         self,
         job_id: str,
     ) -> PrimitiveResult:
-        session = self._get_session()
+        session = await self._get_session()
         async with session.get(
             f"jobs/{job_id}/results",
             headers=self._get_headers(),
@@ -335,7 +358,7 @@ class IBMQuantumPlatformClient(LoggingMixin):
         self,
         job_id: str,
     ) -> JOB_STATUS:
-        session = self._get_session()
+        session = await self._get_session()
         async with session.get(
             f"jobs/{job_id}",
             headers=self._get_headers(),
@@ -388,7 +411,7 @@ class IBMQuantumPlatformClient(LoggingMixin):
         self,
         job_id: str,
     ) -> JobMetrics:
-        session = self._get_session()
+        session = await self._get_session()
         async with session.get(
             f"jobs/{job_id}/metrics",
             headers=self._get_headers(),

--- a/prefect_qiskit/vendors/ibm_quantum/client.py
+++ b/prefect_qiskit/vendors/ibm_quantum/client.py
@@ -19,7 +19,6 @@ import asyncio
 import functools
 import json
 import threading
-from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any, Literal
 
@@ -87,32 +86,6 @@ class SessionCache(LRUCache):
         return endpoint, session
 
 
-class ThreadAsyncLock:
-    """Hybrid lock mechanism to prevent race condition on session cache.
-
-    The :class:`IBMQuantumPlatformClient` implements the :class:`AsyncRuntimeClientInterface`,
-    and we assume its primary concurrency operation is asyncio.
-    However, within Prefect workflows, the :class:`QuantumRuntime` is often used
-    inside Prefect tasks, and such tasks can run through task runners.
-    Because the default task runner in Prefect is the :class:`ThreadPoolTaskRunner`,
-    we also need to consider the race condition by threading.
-
-    Without proper race condition handling, concurrent HTTP requests may
-    create multiple HTTP sessions, resulting in the socket leakage.
-    This hybrid lock prevents the race condition in both scenarios.
-    """
-
-    def __init__(self):
-        self.thread_lock = threading.Lock()
-        self.async_lock = asyncio.Lock()
-
-    @asynccontextmanager
-    async def acquire(self):
-        with self.thread_lock:
-            async with self.async_lock:
-                yield
-
-
 class IBMQuantumPlatformClient(LoggingMixin):
     """Adaptor interface for IBM Quantum Platform cloud client.
 
@@ -135,8 +108,8 @@ class IBMQuantumPlatformClient(LoggingMixin):
 
     AVOID_RETRY = [9999]
 
-    _sessions = SessionCache(maxsize=3)
-    _lock = ThreadAsyncLock()
+    _sessions = SessionCache(maxsize=10)
+    _lock = asyncio.Lock()
 
     def __init__(
         self,
@@ -166,16 +139,20 @@ class IBMQuantumPlatformClient(LoggingMixin):
     async def _get_session(
         self,
     ) -> aiohttp.ClientSession:
-        async with self._lock.acquire():
-            session = self._sessions.get(self.runtime_endpoint_url)
+        async with self._lock:
+            # aiohttp is single thread application because it binds current event loop.
+            # Reusing cached session in different thread doesn't resolve the loop.
+            current_thread = threading.current_thread().name
+            url = self.runtime_endpoint_url
+            session = self._sessions.get((current_thread, url))
             if session is None or session.closed:
-                self.logger.debug(f"Creating new HTTP session for {self.runtime_endpoint_url!r}")
+                self.logger.debug(f"Creating new HTTP session for {url!r} in {current_thread}")
                 session = aiohttp.ClientSession(
-                    base_url=self.runtime_endpoint_url,
+                    base_url=url,
                     timeout=aiohttp.ClientTimeout(30),
                     raise_for_status=True,
                 )
-                self._sessions[self.runtime_endpoint_url] = session
+                self._sessions[(current_thread, url)] = session
         return session
 
     def _get_headers(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 90
+markers = [
+    "real_auth: mark a test to use real IAM authentication"
+]
 
 [tool.dynamic-versioning]
 enable = true

--- a/tests/vendors/ibm/conftest.py
+++ b/tests/vendors/ibm/conftest.py
@@ -9,6 +9,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import os
 from collections.abc import Generator
 from unittest.mock import MagicMock
 
@@ -16,6 +17,7 @@ import pytest
 from ibm_cloud_sdk_core.token_managers import iam_token_manager
 
 from prefect_qiskit.vendors import IBMQuantumCredentials
+from prefect_qiskit.vendors.ibm_quantum.client import IBMQuantumPlatformClient
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -28,10 +30,32 @@ def register_ibm_blocks() -> Generator[None, None, None]:
 @pytest.fixture(autouse=True)
 def mock_iam_token(
     monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Fixture to bypass real IBM cloud IAM authentication for testing."""
+    if request.node.get_closest_marker("real_auth") is not None:
+        return
     monkeypatch.setattr(
         iam_token_manager.IAMTokenManager,
         "get_token",
         MagicMock(return_value="mocked-token"),
     )
+
+
+@pytest.fixture
+def ibm_secrets() -> Generator[IBMQuantumCredentials, None, None]:
+    """Fixture to get secrets from environment variable. Skip when not defined."""
+    api_key = os.environ.get("IBM_API_KEY")
+    crn = os.environ.get("IBM_CRN")
+
+    if api_key is None:
+        pytest.skip("Skipping test because IBM_API_KEY is not defined.")
+    if crn is None:
+        pytest.skip("Skipping test because IBM_CRN is not defined.")
+
+    IBMQuantumPlatformClient._sessions.clear()
+
+    try:
+        yield IBMQuantumCredentials(api_key=api_key, crn=crn)
+    finally:
+        IBMQuantumPlatformClient._sessions.clear()

--- a/tests/vendors/ibm/test_client.py
+++ b/tests/vendors/ibm/test_client.py
@@ -29,6 +29,7 @@ from yarl import URL
 
 from prefect_qiskit.exceptions import RuntimeJobFailure
 from prefect_qiskit.vendors.ibm_quantum import IBMQuantumCredentials
+from prefect_qiskit.vendors.ibm_quantum.client import IBMQuantumPlatformClient
 
 MockHttpRespSetup: TypeAlias = Callable[..., None]
 
@@ -59,12 +60,11 @@ def mock_http_response(
         mock_session = MagicMock()
         setattr(mock_session, method, MagicMock(return_value=mock_response_ctx))
 
-        # Monkeypatch ClientSession with mock
-        mock_session_ctx = AsyncMock()
-        mock_session_ctx.__aenter__.return_value = mock_session
-        mock_session_ctx.__aexit__.return_value = None
-
-        monkeypatch.setattr(aiohttp, "ClientSession", MagicMock(return_value=mock_session_ctx))
+        monkeypatch.setattr(
+            IBMQuantumPlatformClient,
+            "_get_session",
+            MagicMock(return_value=mock_session),
+        )
 
     return _setup
 

--- a/tests/vendors/ibm/test_client.py
+++ b/tests/vendors/ibm/test_client.py
@@ -63,7 +63,7 @@ def mock_http_response(
         monkeypatch.setattr(
             IBMQuantumPlatformClient,
             "_get_session",
-            MagicMock(return_value=mock_session),
+            AsyncMock(return_value=mock_session),
         )
 
     return _setup

--- a/tests/vendors/ibm/test_e2e.py
+++ b/tests/vendors/ibm/test_e2e.py
@@ -133,7 +133,7 @@ def mock_http_response(
     monkeypatch.setattr(
         IBMQuantumPlatformClient,
         "_get_session",
-        MagicMock(return_value=mock_session),
+        AsyncMock(return_value=mock_session),
     )
 
 

--- a/tests/vendors/ibm/test_e2e.py
+++ b/tests/vendors/ibm/test_e2e.py
@@ -25,7 +25,6 @@ import json
 from pathlib import Path
 from unittest.mock import ANY, AsyncMock, MagicMock
 
-import aiohttp
 import pytest
 from prefect import get_client
 from prefect.client.schemas.filters import ArtifactFilter
@@ -35,6 +34,7 @@ from utils import assert_sampler_fidelity
 
 from prefect_qiskit import QuantumRuntime
 from prefect_qiskit.vendors.ibm_quantum import IBMQuantumCredentials
+from prefect_qiskit.vendors.ibm_quantum.client import IBMQuantumPlatformClient
 
 RESPONSE = Path(__file__).parent / "http_response"
 
@@ -130,12 +130,11 @@ def mock_http_response(
         MagicMock(side_effect=post_mock_resp),
     )
 
-    # Monkeypatch ClientSession with mock
-    mock_session_ctx = AsyncMock()
-    mock_session_ctx.__aenter__.return_value = mock_session
-    mock_session_ctx.__aexit__.return_value = None
-
-    monkeypatch.setattr(aiohttp, "ClientSession", MagicMock(return_value=mock_session_ctx))
+    monkeypatch.setattr(
+        IBMQuantumPlatformClient,
+        "_get_session",
+        MagicMock(return_value=mock_session),
+    )
 
 
 def test_sampler_e2e(

--- a/tests/vendors/ibm/test_integration.py
+++ b/tests/vendors/ibm/test_integration.py
@@ -1,0 +1,120 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Test IBM specific implementation of runtime client.
+
+This module is responsible for unit test of the client interface especially for some edge cases.
+The end to end workflow with realistic HTTP responses is covered by test_e2e.py
+"""
+
+import asyncio
+
+import aiohttp
+import pytest
+from prefect import flow, task
+from prefect.futures import wait
+from pytest_mock import MockerFixture
+
+from prefect_qiskit.vendors.ibm_quantum import IBMQuantumCredentials
+
+
+@pytest.mark.real_auth
+async def test_http_session(
+    ibm_secrets: IBMQuantumCredentials,
+):
+    """Test connection to real IBM Qiskit Runtime API."""
+
+    # Not raises
+    client = ibm_secrets.get_client()
+    await client.get_resources()
+
+    # Keep session alive
+    session = await client._get_session()
+    assert not session.closed
+
+
+@pytest.mark.real_auth
+async def test_http_async_parallel(
+    ibm_secrets: IBMQuantumCredentials,
+    mocker: MockerFixture,
+):
+    """Test async API calls reuse the same HTTP session."""
+    spy = mocker.spy(aiohttp.ClientSession, "__init__")
+
+    @task
+    async def _run_many():
+        return await ibm_secrets.get_client().get_resources()
+
+    res1, res2, res3 = await asyncio.gather(_run_many(), _run_many(), _run_many())
+    assert spy.call_count == 1
+    assert res1 == res2 == res3
+
+
+@pytest.mark.real_auth
+async def test_http_thread_parallel(
+    ibm_secrets: IBMQuantumCredentials,
+    mocker: MockerFixture,
+):
+    """Test thread API calls create new HTTP session per thread."""
+    spy = mocker.spy(aiohttp.ClientSession, "__init__")
+
+    @task
+    async def _run_many():
+        return await ibm_secrets.get_client().get_resources()
+
+    @flow
+    async def _test_flow():
+        futures = []
+        for _ in range(3):
+            fut = _run_many.submit()
+            futures.append(fut)
+        responses, _ = wait(futures)
+        return responses
+
+    res1, res2, res3 = await _test_flow()
+
+    assert spy.call_count == 3
+    assert await res1.result() == await res2.result() == await res3.result()
+
+
+@pytest.mark.real_auth
+async def test_http_mix_parallel(
+    ibm_secrets: IBMQuantumCredentials,
+    mocker: MockerFixture,
+):
+    """Test nested async API call inside thread task."""
+    spy = mocker.spy(aiohttp.ClientSession, "__init__")
+
+    @task
+    async def _run_many():
+        return await ibm_secrets.get_client().get_resources()
+
+    @task
+    async def _thread_task():
+        return await asyncio.gather(_run_many(), _run_many(), _run_many())
+
+    @flow
+    async def _test_flow():
+        futures = []
+        for _ in range(3):
+            fut = _thread_task.submit()
+            futures.append(fut)
+        responses, _ = wait(futures)
+        return responses
+
+    outer_responses = await _test_flow()
+
+    # HTTP session is reused within thread
+    assert spy.call_count == 3
+
+    for inner_responses in outer_responses:
+        results = await inner_responses.result()
+        assert results[0] == results[1] == results[2]


### PR DESCRIPTION
This PR changes the internal handling of `aiohttp.ClientSession`. As recommended in [their doc](https://docs.aiohttp.org/en/stable/client_quickstart.html):

> Don’t create a session per request. Most likely you need a session per application which performs all requests together.

`IBMQuantumPlatformClient` now gains a class-level cache mechanism for HTTP session. This means HTTP requests to IBM Quantum share the same session (socket). Since aiohttp design is single thread application (the client binds current event loop during instantiation, and thus it cannot resolve the loop in other threads), this cache mechanism implements a special handling for threads. Namely, HTTP session is created per thread, or Prefect task submitted by the thread pool task runner.

This PR also removes `resource_name` validation with the `QuantumRuntime` block. Since pydantic validation hook is sync and our REST client interface is async, we used to use `run_coro_async` helper function in Prefect, but this internally spawns a new thread for creating an event loop, and the HTTP session created in the thread is also unintentionally cached.

close #11 